### PR TITLE
 Add a shortened & rearranged Finnish press release about the building automation campaign

### DIFF
--- a/_posts/2019-03-18-buildingautomation.md
+++ b/_posts/2019-03-18-buildingautomation.md
@@ -1,14 +1,12 @@
 ---
 layout: pressrelease
 lang: EN
-title: White hats keeping your lights on
+title: Companies launch a campaign to secure Finnish building automation systems
 styles:
   - /vendor/agency/css/agency.min.css
   - /css/badrap.css
 short: >
-  A new TV series inspired Badrap.io and Remod Oy to launch a
-  community effort to rid Finland of insecure building automation
-  systems.
+  A new TV series inspired two companies to launch a community effort to rid Finland of insecure building automation systems.
 releasedate: 2019-03-18
 ---
 
@@ -16,26 +14,27 @@ releasedate: 2019-03-18
 
 ## {{page.title}}
 
-##### A new TV series inspired Badrap.io and Remod Oy to launch a community effort to rid Finland of insecure building automation systems.
+##### A new TV series inspired two companies to launch a community effort to rid Finland of insecure building automation systems.
 
-The Finnish national broadcasting company Yle recently aired a new Docstop series called “Team Whack - everything can be hacked”. In its first episode Team Whack found over 1000 openly accessible Fidelix building automation systems in Finland. The team subsequently demonstrated the involved risks by taking over and remotely controlling one neighbourhood's building automation, including the yard lights and heating.
+The Finnish national broadcasting company Yle recently aired a new Docstop series called “Team Whack - everything can be hacked”. In its first episode Team Whack found over 1000 openly accessible Fidelix building automation systems in Finland. The team subsequently demonstrated the involved risks by taking over and remotely controlling one neighbourhood's building automation, including yard lights, ventilation and heating.
 
-The episode inspired Oulu-based information security company Badrap.io to contact and assist parties that are actively using insecurely installed Fidelix building automation systems in Finland. The need for such a push was made clear by Fidelix's aired statement that security patches seldom find their way to devices in the field.
+The episode inspired Oulu-based information security company Badrap Ltd. to contact and assist parties that are actively using insecurely installed Fidelix building automation systems in Finland. The need for such a push was made clear by Fidelix's aired statement that security patches seldom find their way to devices in the field.
 
-Badrap.io set a bounty for a method to warn the owners of the vulnerable devices, and computer security experts of Remod Oy took up the challenge. Based on publicly available information Remod identified the vulnerable Finnish network addresses to contact those in danger. The same list is also provided to the Badrap.io service, so that anyone concerned about the security of their own network or devices can run the necessary tests to see that if they are vulnerable. The test is publicly available at <https://badrap.io>.
+Badrap set a bounty for a method to warn the owners of the vulnerable devices, and computer security experts of Remod Ltd. took up the challenge. Based on publicly available information Remod identified the vulnerable Finnish network addresses to contact those in danger. The companies also made their findings available at <https://badrap.io> so that anyone can check their own network, for free.
 
-Badrap.io aims to fix this situation by providing a system through which information about similar vulnerabilities and their fixes could effectively be communicated between manufacturers, security experts and end users. “_The Internet is full of vulnerable devices. Owners of most of these have no experience in computer security. We want to make security an easily approachable thing for everyone, and this campaign is one step towards that_”, Badrap.io CEO Jani Kenttälä describes their motivation.
+“_The Internet is full of vulnerable devices. Owners of most of these have no experience in computer security. We want to make security an easily approachable thing for everyone, and this campaign is one step towards that_”, Badrap.io CEO Jani Kenttälä describes their motivation.
 
 More information is available via:
 
-Jani Kenttälä, Badrap.io<br>
+Jani Kenttälä, Badrap Ltd.<br>
 [contact@badrap.io](mailto:contact@badrap.io)<br>
 +358 45 1224 601<br>
 
-Information about Badrap.io: <https://badrap.io/about>
-
-Information about Remod Oy: <https://remod.fi/>
-
-Logos and other graphics: <https://about.badrap.io/press/>
-
 Badrap's free service for checking out network vulnerabilities and data breaches that affect you: <https://badrap.io/>
+
+- Information about the company: <https://badrap.io/about>
+- Logos and other graphics: <https://about.badrap.io/press/>
+
+Information about Remod: <https://remod.fi/>
+
+All six episodes of Team Whack are globally available at https://areena.yle.fi/1-4664681. The first episode has English subtitles.

--- a/_posts/2019-03-21-buildingautomation.md
+++ b/_posts/2019-03-21-buildingautomation.md
@@ -1,16 +1,16 @@
 ---
 layout: pressrelease
 lang: EN
-title: Companies launch a campaign to secure Finnish building automation systems
+title: Finnish companies launch a campaign to secure local building automation systems
 styles:
   - /vendor/agency/css/agency.min.css
   - /css/badrap.css
 short: >
   A new TV series inspired two companies to launch a community effort to rid Finland of insecure building automation systems.
-releasedate: 2019-03-18
+releasedate: 2019-03-21
 ---
 
-# PRESS RELEASE 2019-03-18
+# PRESS RELEASE March 21, 2019
 
 ## {{page.title}}
 

--- a/_posts/2019-03-21-taloautomaatio.md
+++ b/_posts/2019-03-21-taloautomaatio.md
@@ -7,10 +7,10 @@ styles:
   - /css/badrap.css
 short: >
   Ylen uusi hakkerisarja inspiroi Badrap Oy:n ja Remod Oy:n talkootöihin kitkemään Suomesta tietoturvaltaan heikkoja taloautomaatiojärjestelmiä.
-releasedate: 2019-03-XX
+releasedate: 2019-03-21
 ---
 
-# Tiedote XX.3.2019 VAPAA JULKAISTAVAKSI
+# Tiedote 21.3.2019 VAPAA JULKAISTAVAKSI
 
 ## {{page.title}}
 

--- a/_posts/2020-03-XX-taloautomaatio.md
+++ b/_posts/2020-03-XX-taloautomaatio.md
@@ -16,7 +16,7 @@ releasedate: 2019-03-XX
 
 ##### Ylen uusi hakkerisarja inspiroi Badrap Oy:n ja Remod Oy:n talkootöihin kitkemään Suomesta tietoturvaltaan heikkoja taloautomaatiojärjestelmiä.
 
-Yle TV2 esitti hiljattain uuden suomalaisen Docstop-sarjan "Team Whack - kaikki on hakkeroitavissa". Ohjelman ensimmäisessä jaksossa kolmihenkinen Team Whack löysi yli 1000 rakennusautomaatiovalmistaja Fidelixin taloautomaatiojärjestelmää, jotka olivat liian avoimesti hallittavissa Internetistä. Jakson mittaa ryhmä havainnollisti tällaisten järjestelmien riskejä ottamalla Internetin yli haltuunsa kokonaisen naapuruston pihavalaistuksen, ilmastoinnin ja lämmityksen.
+Yle TV2 esitti hiljattain uuden suomalaisen Docstop-sarjan "Team Whack - kaikki on hakkeroitavissa". Ohjelman ensimmäisessä jaksossa kolmihenkinen Team Whack löysi yli 1000 rakennusautomaatiovalmistaja Fidelixin taloautomaatiojärjestelmää, jotka olivat liian avoimesti hallittavissa Internetistä. Jakson mittaan ryhmä havainnollisti tällaisten järjestelmien riskejä ottamalla Internetin yli haltuunsa kokonaisen naapuruston pihavalaistuksen, ilmastoinnin ja lämmityksen.
 
 Jakso innosti oululaista tietoturvayritystä Badrap Oy:ta etsimään ja auttamaan suomalaisia, joilla on vielä käytössään asetuksiltaan turvattomia Fidelix-järjestelmiä. Tarve tempaukseen tiivistyi sarjassa esitettyyn Fidelixin edustaja Antti Koskisen kommenttiin: “_Ongelmana on se, että nämä päivitykset ei kovin usein sinne kentälle valu, varsinkaan tämmöisessä asunto-osakeyhtiötapauksessa._”
 

--- a/_posts/2020-03-XX-taloautomaatio.md
+++ b/_posts/2020-03-XX-taloautomaatio.md
@@ -1,0 +1,40 @@
+---
+layout: pressrelease
+lang: EN
+title: Oululaisyritykset turvaavat taloautomaatiota talkoovoimin
+styles:
+  - /vendor/agency/css/agency.min.css
+  - /css/badrap.css
+short: >
+  Ylen uusi hakkerisarja inspiroi Badrap Oy:n ja Remod Oy:n talkootöihin kitkemään Suomesta tietoturvaltaan heikkoja taloautomaatiojärjestelmiä.
+releasedate: 2019-03-XX
+---
+
+# Tiedote XX.3.2019 VAPAA JULKAISTAVAKSI
+
+## {{page.title}}
+
+##### Ylen uusi hakkerisarja inspiroi Badrap Oy:n ja Remod Oy:n talkootöihin kitkemään Suomesta tietoturvaltaan heikkoja taloautomaatiojärjestelmiä.
+
+Yle TV2 esitti hiljattain uuden suomalaisen Docstop-sarjan "Team Whack - kaikki on hakkeroitavissa". Ohjelman ensimmäisessä jaksossa kolmihenkinen Team Whack löysi yli 1000 rakennusautomaatiovalmistaja Fidelixin taloautomaatiojärjestelmää, jotka olivat liian avoimesti hallittavissa Internetistä. Jakson mittaa ryhmä havainnollisti tällaisten järjestelmien riskejä ottamalla Internetin yli haltuunsa kokonaisen naapuruston pihavalaistuksen, ilmastoinnin ja lämmityksen.
+
+Jakso innosti oululaista tietoturvayritystä Badrap Oy:ta etsimään ja auttamaan suomalaisia, joilla on vielä käytössään asetuksiltaan turvattomia Fidelix-järjestelmiä. Tarve tempaukseen tiivistyi sarjassa esitettyyn Fidelixin edustaja Antti Koskisen kommenttiin: “_Ongelmana on se, että nämä päivitykset ei kovin usein sinne kentälle valu, varsinkaan tämmöisessä asunto-osakeyhtiötapauksessa._”
+
+Badrap asetti palkkion haavoittuvien laitteiden omistajien varoittamiseksi ja suomalainen Remod Oy tietoturva-asiantuntijoineen tarttui haasteeseen. Julkisten tietojen avulla he etsivät suomalaiset haavoittuvat verkko-osoitteet ja niiden omistajat varoittaakseen vaarassa olevia. Yritykset myös lisäsivät havainnot tarjolle osoitteeseen <https://badrap.io>, jotta kuka tahansa voi testatata verkko-osoitteensa itse ilmaiseksi.
+
+“_Internet on pullollaan haavoittuvia laitteita. Useimpien omistajilla ei ole tietoturvakokemusta. Haluamme tehdä tietoturvan kaikille helposti lähestyttäväksi asiaksi, olipa kyseessä sitten yksittäiset henkilöt tai organisaatiot. Tämä kampanja auttaa meitä tekemään työmme paremmin_”, kuvaa Badrapin toimitusjohtaja Jani Kenttälä motivaatioitaan.
+
+Lisätietoja tempauksesta antaa ensisijaisesti:
+
+Jani Kenttälä, Badrap.io<br>
+contact@badrap.io<br>
++358 45 1224 601<br>
+
+Tietoa Badrap.io:sta: <https://badrap.io/about>
+
+- Badrapin ilmaispalvelu omien verkkohaavoittuvuuksiesi ja tietovuotojesi tarkistamiseksi: <https://badrap.io/>
+- Logot ja muu grafiikka: <https://about.badrap.io/press/>
+
+Tietoa Remodista: <https://remod.fi/>
+
+Team Whackin kaikki kuusi jaksoa ovat nyt katsottavissa Yle Areenasta osoitteessa <https://areena.yle.fi/1-4664681>.


### PR DESCRIPTION
This pull request adds a new version of the buildin automation campaign press release in Finnish. The English version is also brought in line with the Finnish version.

The press release doesn't currently have a release date set, so the date is marked as `XX` in the filename, front matter and article itself. Those need to be fixed before releasing.